### PR TITLE
5 CVE-2016-5394 POV fails the same way before and after vuln fixed

### DIFF
--- a/CVE-2016-5394/README.md
+++ b/CVE-2016-5394/README.md
@@ -1,24 +1,14 @@
-# [CVE-2016-5394 -- sling] (https://nvd.nist.gov/vuln/detail/CVE-2016-5394 )  from [vul4j](https://github.com/tuhh-softsec/vul4j)
+# [CVE-2016-5394 -- sling](https://nvd.nist.gov/vuln/detail/CVE-2016-5394) from [vul4j](https://github.com/tuhh-softsec/vul4j)
 
-Project uses `org.apache.sling:org.apache.sling.xss:1.0.8` , tests from https://github.com/apache/sling/commit/7d2365a248943071a44d8495655186e4f14ea294   
+Project uses `org.apache.sling:org.apache.sling.xss:1.0.8`, tests from https://github.com/apache/sling/commit/7d2365a248943071a44d8495655186e4f14ea294   
 as specified in [vul4j](https://github.com/tuhh-softsec/vul4j).
 
 Some minor changes made: 
-1. JUnit version replaced by Junit5, not using vintage (issues detecting tests)
-2. several additional dependency
-3. resource `resources/SLING-INF/content/config.xml` added needed in fixture, some additional code added whether file exists. The location is unusal but better than the original location in `src/main/resources/SLING-INF/content/config.xml` referenced as file (not resource)
+1. JUnit version replaced by JUnit5, not using vintage (issues detecting tests) -- also note different argument order for `assertEquals()`!
+2. several additional dependencies
+3. resource `resources/SLING-INF/content/config.xml` added (needed in fixture), some additional code added whether file exists. The location is unusual but better than the original location in `src/main/resources/SLING-INF/content/config.xml`; now referenced as file (not resource)
 
-Note that the tests __fail__ indicating the vulnerability! There is no later version of sling available in the Maven repository that is compatible with the dependencies, and makes these tests
-pass as APIs the tests depends on also change. In particular, tests still fail when replacing the sling dependency by `org.apache.sling:org.apache.sling.xss:1.0.12` which is mentioned
-as patched version in the [GHSA](https://github.com/advisories/GHSA-xwf4-88xr-hx2j).
+Note that the tests __fail__ indicating the vulnerability!
 
-
-
-
-  
-
-
- 
-
- 
-
+Tests pass when replacing the sling dependency by `org.apache.sling:org.apache.sling.xss:1.0.12` which is mentioned
+as the patched version in the [GHSA](https://github.com/advisories/GHSA-xwf4-88xr-hx2j).

--- a/CVE-2016-5394/src/test/java/org/apache/sling/xss/impl/XSSAPIImplTest.java
+++ b/CVE-2016-5394/src/test/java/org/apache/sling/xss/impl/XSSAPIImplTest.java
@@ -422,7 +422,7 @@ public class XSSAPIImplTest {
             String source = aTestData[0];
             String expected = aTestData[1];
 
-            assertEquals("Encoding '" + source + "'", expected, xssAPI.encodeForJSString(source));
+            assertEquals(expected, xssAPI.encodeForJSString(source), "Encoding '" + source + "'");
         }
     }
 
@@ -454,7 +454,7 @@ public class XSSAPIImplTest {
             String source = aTestData[0];
             String expected = aTestData[1];
 
-            assertEquals("Validating Javascript token '" + source + "'", expected, xssAPI.getValidJSToken(source, RUBBISH));
+            assertEquals(expected, xssAPI.getValidJSToken(source, RUBBISH), "Validating Javascript token '" + source + "'");
         }
     }
 


### PR DESCRIPTION
The issue was that the order of the arguments to 3-argument `assertEquals()` changed between [JUnit4](https://junit.org/junit4/javadoc/4.8/org/junit/Assert.html#assertEquals(java.lang.String,%20java.lang.Object,%20java.lang.Object)) and [JUnit5](https://junit.org/junit5/docs/5.0.1/api/org/junit/jupiter/api/Assertions.html#assertEquals-java.lang.Object-java.lang.Object-java.lang.String-), and when the `expected` and `actual` arguments are strings, type checking does not catch this!

With the fix, we now get 2 "normal" test failures at `org.apache.sling:org.apache.sling.xss:1.0.8`:

```
$ cd CVE-2016-5394
$ mvn test
-- snip --
[ERROR] Failures: 
[ERROR]   XSSAPIImplTest.testEncodeForJSString:426 Encoding 'break"out' ==> expected: <break\x22out> but was: <break\"out>
[ERROR]   XSSAPIImplTest.testGetValidJSToken:459 Validating Javascript token ''literal'); junk'' ==> expected: <'literal\x27); junk'> but was: <'literal\'); junk'>
[INFO] 
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
-- snip --
```

and test success at v1.0.12, as expected.