### PR TITLE
Add CVE-2016-0779

### DIFF
--- a/CVE-2016-0779/README.md
+++ b/CVE-2016-0779/README.md
@@ -1,0 +1,13 @@
+# [CVE-2016-0779](https://nvd.nist.gov/vuln/detail/CVE-2016-0779) based on [`VUL4J-37`](https://github.com/tuhh-softsec/vul4j)
+
+Project uses `org.apache.openejb:apache-tomee`, and the test added in https://github.com/apache/tomee/commit/58cdbbef9c77ab2b44870f9d606593b49cde76d9 as specified in `VUL4J-37`.
+
+NOTE: [The NVD "rejects" vul4j's original CVE `CVE-2015-8581`](https://nvd.nist.gov/vuln/detail/CVE-2015-8581) as a dupe of `CVE-2016-0779`. This PoV is based on the latter CVE.
+
+**NOTE: [The Maven central repo](https://mvnrepository.com/artifact/org.apache.openejb/apache-tomee) does NOT currently show any versions of this artifact as being vulnerable to either this CVE or the original!**
+
+**NOTE: According to the CVE, this vulnerability affects not only `org.apache.openejb:apache-tomee` versions before `1.7.4`, but also `org.apache.tomee:apache-tomee` versions before `7.0.0-M3`.** The metadata in `pom.xml` and `pov-project.json` here only deals with the first set of GAVs (with group `org.apache.openejb`), which turns out to be older, but I also verified that the 2 versions of `org.apache.tomee:apache-tomee` before `7.0.0-M3` (namely `7.0.0-M2` and `7.0.0-M1`) fail the test while `7.0.0-M3` passes. No code changes were required for this.
+
+Since [the underlying GHSA](https://github.com/advisories/GHSA-g7jw-7782-jjv9) has not yet been verified, it isn't retrievable from https://api.osv.dev/v1/vulns/GHSA-g7jw-7782-jjv9 (see issue #15) so could not be used to generate `pov-project.json` automatically. I created it manually by testing each of the GAVs listed at https://mvnrepository.com/artifact/org.apache.openejb/apache-tomee; most (all 1.6.x or earlier) didn't build at all, but I have left them in the `pov-project.json` for now.
+
+`1.7.3`->`1.7.4` is a failure->success transition for `org.apache.openejb:apache-tomee`, and `7.0.0-M2`->`7.0.0-M3` is a failure->success transition for `org.apache.tomee:apache-tomee`.

--- a/CVE-2016-0779/pom.xml
+++ b/CVE-2016-0779/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>io.github.jensdietrich.xshady</groupId>
+    <artifactId>CVE-2016-0779</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <description>CVE-2016-0779 POV</description>
+    <name>CVE-2016-0779</name>
+
+    <properties>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.openejb</groupId>
+            <artifactId>apache-tomee</artifactId>
+            <version>1.7.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/CVE-2016-0779/pov-project.json
+++ b/CVE-2016-0779/pov-project.json
@@ -1,0 +1,26 @@
+{
+  "id": "CVE-2016-0779",
+  "artifact": "org.apache.openejb:apache-tomee",
+  "vulnerableVersions": [
+    "1.7.3",
+    "1.7.2",
+    "1.7.1",
+    "1.7.0",
+    "1.6.0.2",
+    "1.6.0.1",
+    "1.6.0",
+    "1.5.2",
+    "1.5.1",
+    "1.5.0",
+    "1.0.0",
+    "1.0.0-beta-2",
+    "1.0.0-beta-1"
+  ],
+  "fixVersion": "1.7.4",
+  "testSignal": "failure",
+  "references": [
+    "https://nvd.nist.gov/vuln/detail/CVE-2016-0779",
+    "https://github.com/advisories/GHSA-g7jw-7782-jjv9",
+    "https://github.com/tuhh-softsec/vul4j/tree/VUL4J-37"
+  ]
+}

--- a/CVE-2016-0779/src/test/java/org/apache/openejb/core/rmi/BlacklistClassResolverTest.java
+++ b/CVE-2016-0779/src/test/java/org/apache/openejb/core/rmi/BlacklistClassResolverTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.openejb.core.rmi;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class BlacklistClassResolverTest {
+    @Test
+    public void wildcard() {
+        final BlacklistClassResolver classResolver = new BlacklistClassResolver(new String[]{"*"}, new String[] {"white", "com.white"});
+        assertTrue(classResolver.isBlacklisted("white.Foo"));
+        assertTrue(classResolver.isBlacklisted("com.white.test"));
+        assertTrue(classResolver.isBlacklisted("other.test"));
+    }
+}


### PR DESCRIPTION
`mvn test` Fail->Succeed on changing `org.apache.openejb:apache-tomee:1.7.3` dep to `1.7.4`, or changing `org.apache.apache:apache-tomee:7.0.0-M2` to `7.0.0-M3` (note the different group).

Based on branch `fix-leftover-vulnable-typos`.