### PR TITLE
Rename `testSignal` field to `testSignalWhenVulnerable`

### DIFF
--- a/CVE-2016-0779/pov-project.json
+++ b/CVE-2016-0779/pov-project.json
@@ -17,7 +17,7 @@
     "1.0.0-beta-1"
   ],
   "fixVersion": "1.7.4",
-  "testSignal": "failure",
+  "testSignalWhenVulnerable": "failure",
   "references": [
     "https://nvd.nist.gov/vuln/detail/CVE-2016-0779",
     "https://github.com/advisories/GHSA-g7jw-7782-jjv9",

--- a/CVE-2018-1002201/pov-project.json
+++ b/CVE-2018-1002201/pov-project.json
@@ -13,7 +13,7 @@
     "1.9"
   ],
   "fixVersion": "1.13",
-  "testSignal": "success",
+  "testSignalWhenVulnerable": "success",
   "references": [
     "https://nvd.nist.gov/vuln/detail/CVE-2018-1002201",
     "https://github.com/advisories/GHSA-qcf3-9vmh-xw4r"

--- a/CVE-2018-1324/pov-project.json
+++ b/CVE-2018-1324/pov-project.json
@@ -9,7 +9,7 @@
     "1.15"
   ],
   "fixVersion": "1.16.1",
-  "testSignal": "success",
+  "testSignalWhenVulnerable": "success",
   "references": [
     "https://nvd.nist.gov/vuln/detail/CVE-2018-1324",
     "https://github.com/advisories/GHSA-h436-432x-8fvx"

--- a/CVE-2018-8017/pov-project.json
+++ b/CVE-2018-8017/pov-project.json
@@ -21,7 +21,7 @@
     "1.9"
   ],
   "fixVersion": "1.19",
-  "testSignal": "success",
+  "testSignalWhenVulnerable": "success",
   "references": [
     "https://nvd.nist.gov/vuln/detail/CVE-2018-8017",
     "https://github.com/advisories/GHSA-j53j-gmr9-h8g3"

--- a/tools/README.md
+++ b/tools/README.md
@@ -26,7 +26,7 @@ This folder contains tools for creating and maintaining proof-of-vulnerability p
   // Single version where vulnerability is fixed
   "fixVersion": "1.13",
   // Whether JUnit succeeds or fails in the presence of the vulnerability
-  "testSignal": "success"
+  "testSignalWhenVulnerable": "success"
 }
 
 ```

--- a/tools/create-pov-project.js
+++ b/tools/create-pov-project.js
@@ -91,7 +91,7 @@ const xshady = {
     artifact: affected.package.name,
     vulnerableVersions: affected.versions,
     fixVersion: null,
-    testSignal: "success|failure",
+    testSignalWhenVulnerable: "success|failure",
     references: [nvdUrl + cve, ghsaUrl + ghsa]
 }
 

--- a/tools/pov-project-schema.cue
+++ b/tools/pov-project-schema.cue
@@ -6,7 +6,7 @@
 	// At least one version must be provided
 	vulnerableVersions: [string, ...string]
 	fixVersion: string
-	testSignal: "success" | "failure"
+	testSignalWhenVulnerable: "success" | "failure"
 	// URL references, at least one must be provided
 	references: [string, ...string]
 }


### PR DESCRIPTION
As discussed [here](https://github.com/jensdietrich/xshady/issues/11#issuecomment-1704014236). I'll make a corresponding follow-up PR in the `shadedetector` repo shortly.