### PR TITLE
Make artifact name in pov-project.json agree with pom.xml

### DIFF
--- a/CVE-2018-8017/pov-project.json
+++ b/CVE-2018-8017/pov-project.json
@@ -1,6 +1,6 @@
 {
   "id": "CVE-2018-8017",
-  "artifact": "org.apache.tika:tika-core",
+  "artifact": "org.apache.tika:tika-parsers",
   "vulnerableVersions": [
     "1.10",
     "1.11",


### PR DESCRIPTION
The spreadsheet shows `tika-parsers`, as does `pom.xml`, so I think this PR's change is in the right direction -- @alexjordan could you please check?

Making these agree is needed to enable https://github.com/jensdietrich/shadedetector/issues/14. 