### PR TITLE
Update pom.xml to later version (1.30) that is still vulnerable

### DIFF
--- a/CVE-2022-38751/pom.xml
+++ b/CVE-2022-38751/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.25</version>
+            <version>1.30</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
May as well record the latest vulnerable version.

Tested with `mvn clean test`.