### PR TITLE
Record JDK version in metadata

### DIFF
--- a/CVE-2016-2510/pov-project.json
+++ b/CVE-2016-2510/pov-project.json
@@ -6,6 +6,7 @@
   ],
   "fixVersion": "2.0b6",
   "testSignalWhenVulnerable": "success",
+  "jdkVersion": "8",
   "references": [
     "https://nvd.nist.gov/vuln/detail/CVE-2016-2510",
     "https://github.com/advisories/GHSA-gxg6-rc6c-v673"

--- a/tools/pov-project-schema.cue
+++ b/tools/pov-project-schema.cue
@@ -6,6 +6,8 @@
 	// At least one version must be provided
 	vulnerableVersions: [string, ...string]
 	fixVersion: string
+	// The JDK version to build and run the PoV tests with
+	jdkVersion?: "7" | "8" | "11" | "17"
 	testSignalWhenVulnerable: "success" | "failure"
 	// URL references, at least one must be provided
 	references: [string, ...string]


### PR DESCRIPTION
Add an optional `jdkVersion` field, with a constrained set of permitted values, to use for building and testing PoVs. `shadedetector` will use this to generate a suitable `JAVA_HOME` environment variable setting. Set this field for `CVE-2016-2510`.

Why not just add an optional `environment` field instead, which is more flexible? Because that would mean hardcoding `JAVA_HOME=/some/path`, and the right path can vary across platforms.