### PR TITLE
Metadata for CVE-2015-6420

### DIFF
--- a/CVE-2015-6420/README.md
+++ b/CVE-2015-6420/README.md
@@ -5,7 +5,7 @@ The payload and test used is based on
 
 The actual test is identical to the test used to verify CVE-2015-7501 . 
 
-
+Requires JDK 8. Succeeds (indicating vulnerability) at `3.2.1`; fails (indicating no vulnerability) at `3.2.2`.
 
 
 

--- a/CVE-2015-6420/pov-project.json
+++ b/CVE-2015-6420/pov-project.json
@@ -1,0 +1,24 @@
+{
+  "id": "CVE-2015-6420",
+  "artifact": "commons-collections:commons-collections",
+  "vulnerableVersions": [
+    "1.0",
+    "2.0",
+    "2.0.20020914.015953",
+    "2.0.20020914.020746",
+    "2.0.20020914.020858",
+    "2.1",
+    "2.1.1",
+    "3.0",
+    "3.0-dev2",
+    "3.1",
+    "3.2",
+    "3.2.1"
+  ],
+  "fixVersion": null,
+  "testSignalWhenVulnerable": "success",
+  "references": [
+    "https://nvd.nist.gov/vuln/detail/CVE-2015-6420",
+    "https://github.com/advisories/GHSA-6hgm-866r-3cjv"
+  ]
+}

--- a/CVE-2015-6420/pov-project.json
+++ b/CVE-2015-6420/pov-project.json
@@ -16,6 +16,7 @@
     "3.2.1"
   ],
   "fixVersion": "3.2.2",
+  "jdkVersion": "8",
   "testSignalWhenVulnerable": "success",
   "references": [
     "https://nvd.nist.gov/vuln/detail/CVE-2015-6420",

--- a/CVE-2015-6420/pov-project.json
+++ b/CVE-2015-6420/pov-project.json
@@ -15,7 +15,7 @@
     "3.2",
     "3.2.1"
   ],
-  "fixVersion": null,
+  "fixVersion": "3.2.2",
   "testSignalWhenVulnerable": "success",
   "references": [
     "https://nvd.nist.gov/vuln/detail/CVE-2015-6420",


### PR DESCRIPTION
Testing for this PoV requires JDK 8. I manually tested `3.2.1` (the vulnerable version in `pom.xml`) and `3.2.2` (the next available version in the [Maven Central Repo](https://central.sonatype.com/artifact/commons-collections/commons-collections/versions)) with

```
JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 mvn clean test
```

to confirm: the former succeeds, the latter fails.

Upcoming changes to `shadedetector` will supply the same environment variable value for `JAVA_HOME` based on `jdkVersion`.
