### PR TITLE
Metadata for CVE-2015-7501

### DIFF
--- a/CVE-2015-7501/README.md
+++ b/CVE-2015-7501/README.md
@@ -3,7 +3,7 @@
 The payload and test used is based on 
 [ysoserial](https://github.com/frohoff/ysoserial), `ysoserial.payloads.CommonsCollections5.java`.
 
-
+Requires JDK 8. Succeeds (indicating vulnerability) at `3.2.1`; fails (indicating no vulnerability) at `3.2.2`.
 
 
 

--- a/CVE-2015-7501/pov-project.json
+++ b/CVE-2015-7501/pov-project.json
@@ -16,6 +16,7 @@
     "3.2.1"
   ],
   "fixVersion": "3.2.2",
+  "jdkVersion": "8",
   "testSignalWhenVulnerable": "success",
   "references": [
     "https://nvd.nist.gov/vuln/detail/CVE-2015-7501",

--- a/CVE-2015-7501/pov-project.json
+++ b/CVE-2015-7501/pov-project.json
@@ -1,0 +1,24 @@
+{
+  "id": "CVE-2015-7501",
+  "artifact": "commons-collections:commons-collections",
+  "vulnerableVersions": [
+    "1.0",
+    "2.0",
+    "2.0.20020914.015953",
+    "2.0.20020914.020746",
+    "2.0.20020914.020858",
+    "2.1",
+    "2.1.1",
+    "3.0",
+    "3.0-dev2",
+    "3.1",
+    "3.2",
+    "3.2.1"
+  ],
+  "fixVersion": null,
+  "testSignalWhenVulnerable": "success",
+  "references": [
+    "https://nvd.nist.gov/vuln/detail/CVE-2015-7501",
+    "https://github.com/advisories/GHSA-fjq5-5j5f-mvxh"
+  ]
+}

--- a/CVE-2015-7501/pov-project.json
+++ b/CVE-2015-7501/pov-project.json
@@ -15,7 +15,7 @@
     "3.2",
     "3.2.1"
   ],
-  "fixVersion": null,
+  "fixVersion": "3.2.2",
   "testSignalWhenVulnerable": "success",
   "references": [
     "https://nvd.nist.gov/vuln/detail/CVE-2015-7501",


### PR DESCRIPTION
Testing for this PoV requires JDK 8. I manually tested 3.2.1 (the vulnerable version in pom.xml) and 3.2.2 (the next available version in the [Maven Central Repo](https://central.sonatype.com/artifact/commons-collections/commons-collections/versions)) with

```
JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 mvn clean test
```

to confirm: the former succeeds, the latter fails.

Upcoming changes to `shadedetector` will supply the same environment variable value for `JAVA_HOME` based on `jdkVersion`.