### PR TITLE
Improve shadedetector run script generator

### DIFF
--- a/tools/run_shadedetector_on_all.pl
+++ b/tools/run_shadedetector_on_all.pl
@@ -10,11 +10,40 @@ my $cacheDir = (-d $localScratchCacheDir ? $localScratchCacheDir : "$ENV{HOME}/c
 my $jarPath = "../target/shadedetector.jar";
 my $xshadyPath = "$ENV{HOME}/code/xshady";
 
-foreach my $d (<CVE-*>) {
-	# -g, -a, -v, -sig and any JAVA_HOME=... setting are now all determined from pov-project.json
-	my $cmd = "/usr/bin/time java -jar $jarPath -vul $xshadyPath/$d -l log$n-$d.log -vov vuln_final --stats stats$n-$d.log -o1 csv.details?dir=details$n-$d -o2 csv.summary?file=summary$n-$d.csv -cache $cacheDir";
+my $mode = "make";
 
-	print "$cmd\n";
+if (@ARGV && $ARGV[0] eq '--mode') {
+	$mode = $ARGV[1];
+}
+
+die "Unknown mode" if $mode !~ /^(?:make|shell-script)$/;
+print STDERR "Generating run script in $mode mode.\n";
+
+print "# Generated at " . localtime . " by $0\n";
+
+my @targets;
+my @rules;
+
+foreach my $d (<CVE-*>) {
+	my $statsFName = "stats$n-$d.log";
+	my $pomFName = `realpath $d/pom.xml`;
+	chomp $pomFName;
+
+	# -g, -a, -v, -sig and any JAVA_HOME=... setting are now all determined from pov-project.json
+	my $cmd = "/usr/bin/time java -jar $jarPath -vul $xshadyPath/$d -l log$n-$d.log -vov vuln_final --stats $statsFName -o1 csv.details?dir=details$n-$d -o2 csv.summary?file=summary$n-$d.csv -cache $cacheDir";
+
+	if ($mode eq 'make') {
+		push @targets, $statsFName;
+		push @rules, "$statsFName: $pomFName\n\t$cmd\n\n";
+
+	} else {
+		print "$cmd\n";
+	}
 
 	++$n;
+}
+
+if ($mode eq 'make') {
+	print join(" \\\n\t", "all:", @targets), "\n\n";
+	print @rules;
 }

--- a/tools/run_shadedetector_on_all.pl
+++ b/tools/run_shadedetector_on_all.pl
@@ -11,17 +11,8 @@ my $jarPath = "../target/shadedetector.jar";
 my $xshadyPath = "$ENV{HOME}/code/xshady";
 
 foreach my $d (<CVE-*>) {
-	my $gav = `tools/guess_gav.pl < $d/pom.xml`;
-	chomp $gav;
-	my $exitStatus = `cat $d/mvn_clean_test.exitstatus`;
-	chomp $exitStatus;
-	my $sig = ($exitStatus eq '0' ? 'success' : 'failure');
-
-	#print "$d: $gav\n";
-	my ($g, $a, $v) = split /:/, $gav;
-
-	# For now just assume exit status 1 means failures, not errors (it's actually the case for now).
-	my $cmd = "/usr/bin/time java -jar $jarPath -g $g -a $a -v $v -vul $xshadyPath/$d -sig $sig -l log$n-$d.log -vos vuln_staging -vov vuln_final --stats stats$n-$d.log -o1 csv.details?dir=details$n-$d -o2 csv.summary?file=summary$n-$d.csv -cache $cacheDir";
+	# -g, -a, -v, -sig and any JAVA_HOME=... setting are now all determined from pov-project.json
+	my $cmd = "/usr/bin/time java -jar $jarPath -vul $xshadyPath/$d -l log$n-$d.log -vov vuln_final --stats stats$n-$d.log -o1 csv.details?dir=details$n-$d -o2 csv.summary?file=summary$n-$d.csv -cache $cacheDir";
 
 	print "$cmd\n";
 


### PR DESCRIPTION
It's improved in that

- all info that can be read from `pov-project.json` files is left out of the command line, and
- it can now generate a `Makefile` directly (running with `mkdir results && cd results && nohup time make -j 4 -k -f ../Makefile &` works nicely on my Linux VM).

It's still Perl, though 😆