### PR TITLE
Fix test for CVE-2019-0225

### DIFF
--- a/CVE-2019-0225/README.md
+++ b/CVE-2019-0225/README.md
@@ -8,20 +8,7 @@ Some minor changes made:
 1. JUnit version replaced by Junit5 with JUnit4 support through vintage
 2. additional dependency providing mock APIs added: `net.sourceforge.stripes:stripes:1.7.0-async-beta`
 
-Note that the tests __fail__ indicating the vulnerability! There is no later version of jspwiki available in the Maven repository that makes these tests
-pass as APIs the tests depends on also change. In particular, the required class `org.apache.wiki.auth.TestAuthorizer` needs to implement additional methods 
-in `org.apache.wiki.auth.authorize.WebAuthorizer` in `org.apache.jspwiki:jspwiki-main:2.11.0.M7`.  
+Note that the tests __fail__ indicating the vulnerability!
 
-Also, in 2.11.0 , `WikiEngine` expects that *""JSPWiki requires a container which supports at least version 3.1 of Servlet specification"* and 
-enforces this by throwing an exception. However, the mock container provided in `net.sourceforge.stripes:stripes:1.7.0-async-beta`
-only supports container version `2.*`. 
-
-
-
-  
-
-
- 
-
- 
-
+The commit, apache/jspwiki@88d89d6, that contains the original patch to fix the vulnerability also contains a new test -- but that test has a bug, which
+was fixed a few minutes later in apache/jspwiki@3ad9e5e. Our test has the same fix.

--- a/CVE-2019-0225/pom.xml
+++ b/CVE-2019-0225/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.apache.jspwiki</groupId>
             <artifactId>jspwiki-main</artifactId>
-            <version>2.11.0.M6</version>
+            <version>2.11.0.M2</version>
         </dependency>
 
         <dependency>

--- a/CVE-2019-0225/pov-project.json
+++ b/CVE-2019-0225/pov-project.json
@@ -11,6 +11,7 @@
     "2.11.0.M1",
     "2.11.0.M2"
   ],
+  "fixVersion": "2.11.0.M3",
   "testSignalWhenVulnerable": "failure",
   "references": [
     "https://nvd.nist.gov/vuln/detail/CVE-2019-0225",

--- a/CVE-2019-0225/pov-project.json
+++ b/CVE-2019-0225/pov-project.json
@@ -1,6 +1,6 @@
 {
   "id": "CVE-2019-0225",
-  "artifact": "org.apache.jspwiki:jspwiki-war",
+  "artifact": "org.apache.jspwiki:jspwiki-main",
   "vulnerableVersions": [
     "2.10.0",
     "2.10.1",

--- a/CVE-2019-0225/src/test/java/org/apache/wiki/WikiServletTest.java
+++ b/CVE-2019-0225/src/test/java/org/apache/wiki/WikiServletTest.java
@@ -41,7 +41,7 @@ public class WikiServletTest {
         wikiServlet.doGet( req, res );
         wikiServlet.destroy();
 
-        Assertions.assertEquals( "/Wiki.jsp?page=wiki%2FWiki.jsp&", req.getForwardUrl() );
+        Assertions.assertEquals( "/Wiki.jsp?page=Main&", req.getForwardUrl() );
     }
 
     @Test
@@ -56,7 +56,7 @@ public class WikiServletTest {
         wikiServlet.doPost( req, res );
         wikiServlet.destroy();
 
-        Assertions.assertEquals( "/Wiki.jsp?page=Edit.jsp&", req.getForwardUrl() );
+        Assertions.assertEquals( "/Wiki.jsp?page=Main&", req.getForwardUrl() );
     }
 
 }


### PR DESCRIPTION
Fixes #36, the same way https://github.com/apache/jspwiki/commit/3ad9e5e5d9748750d49cc17ade48637dc0effbc6 fixed the broken test originally introduced in https://github.com/apache/jspwiki/commit/88d89d6523802c044cfcb7930cba40d8eeb21da2.